### PR TITLE
Fix card background color for 0.113.0

### DIFF
--- a/themes/google_dark_theme.yaml
+++ b/themes/google_dark_theme.yaml
@@ -51,7 +51,7 @@ Google Dark Theme:
   ha-card-border-radius: "10px"
   ha-card-box-shadow: 1px 1px 5px 0px rgb(12, 12, 14)
   paper-dialog-background-color: var(--card-background-color)
-  paper-card-background-color: var(--card-background-color)
+  ha-card-background-color: var(--card-background-color)
   paper-listbox-background-color: var(--card-background-color)
   # Switches
   switch-checked-button-color: "#5F9BEA"


### PR DESCRIPTION
Changes paper-card-background-color to ha-card-background.
Fixes: https://github.com/JuanMTech/google_dark_theme/issues/26#issue-663947389