### PR TITLE
Fix sliders and disabled arrows

### DIFF
--- a/themes/google_dark_theme.yaml
+++ b/themes/google_dark_theme.yaml
@@ -19,7 +19,7 @@ Google Dark Theme:
   primary-text-color: "#BDC1C6"
   secondary-text-color: "#BDC1C6"
   text-primary-color: "#FFFFFF"
-  disabled-text-color: "#000000"
+  disabled-text-color: "#717171"
   # Sidebar Menu
   sidebar-icon-color: var(--app-header-text-color)
   sidebar-text-color: "#BDC1C6"


### PR DESCRIPTION
Resolves #33
Undoing a change made recently to fix the color of sliders and disabled arrows.
`#000000` -> `#717171`
Note I'm still using Home Assistant 0.109.6 but I'm assuming this issue exists on the latest version.
Before:
![before screenshot](https://user-images.githubusercontent.com/16645707/89103164-1d780380-d453-11ea-8410-2e5e7dc0882c.png)
After
![after screenshot](https://user-images.githubusercontent.com/16645707/89103170-2537a800-d453-11ea-9ebe-b0b3a06d7339.png)
